### PR TITLE
add clear cache fn

### DIFF
--- a/replicated-splinterdb/Dockerfile
+++ b/replicated-splinterdb/Dockerfile
@@ -16,7 +16,8 @@ COPY replicated-splinterdb replicated-splinterdb
 COPY HdrHistogram_c HdrHistogram_c
 COPY CMakeLists.txt /build
 
-RUN cmake -DBIND_SPLINTERDB=ON . && make -j `nproc`
+RUN make -C replicated-splinterdb/replicated-splinterdb/third-party/splinterdb BUILD_VERBOSE=1 LIBDIR=/build /build/libsplinterdb.so -j `nproc` \
+    && cmake -DBIND_SPLINTERDB=ON . && make -j `nproc`
 
 FROM neilk3/splinterdb-run-env as run
 

--- a/replicated-splinterdb/README.md
+++ b/replicated-splinterdb/README.md
@@ -22,3 +22,12 @@ docker run --rm -it \
     --entrypoint /bin/bash \
     neilk3/replicated-splinterdb
 ```
+
+
+1. make all
+2. ./replicated-splinterdb/start_servers.sh 250
+3. docker run -it --rm --network splinterdb-network neilk3/ycsb-replicated-splinterdb -s -load -db replicated-splinterdb -p replicated_splinterdb.host=replicated-splinterdb-node-1 -threads 10 -P 700k 
+4. ./replicated-splinterdb/client.sh 1 -e dumpcache
+4. ./replicated-splinterdb/client.sh 1 -e clearcache
+cp -r caches caches-old
+4. ./replicated-splinterdb/client.sh 1 -e dumpcache

--- a/workloads/700k
+++ b/workloads/700k
@@ -1,4 +1,4 @@
-recordcount=700000
+recordcount=10000
 fieldlength=1024
 zeropadding=20
 


### PR DESCRIPTION
add a clear cache function to help run YCSB workloads sequentially without closing and reopening db.